### PR TITLE
Add install condition to check for PS v3.0+ to fix #87.

### DIFF
--- a/Package/Installer/Bundle.wxs
+++ b/Package/Installer/Bundle.wxs
@@ -1,15 +1,21 @@
 <?xml version="1.0" ?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension"
+      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Bundle Name="OneGet v!(bind.packageVersion.OneGet.msi)" Manufacturer="OneGet Project"
           Version="!(bind.packageVersion.OneGet.msi)" UpgradeCode="0FCE07AA-AC5F-4CB4-AEE5-C2CC74E060AE"
           Compressed="yes">
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
       <bal:WixStandardBootstrapperApplication
-          LicenseUrl="https://raw.githubusercontent.com/OneGet/oneget/master/LICENSE"
+          LicenseUrl="http://j.mp/onegetlicense"
           LogoFile="logo.png"
           SuppressOptionsUI="yes" />
     </BootstrapperApplicationRef>
+
+    <util:RegistrySearch Variable="PowerShellVersion" Root="HKLM" Key="SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine"
+                         Value="PowerShellVersion" />
+
+    <bal:Condition Message="[WixBundleName] requires PowerShell v3.0 or newer. To install a newer version of PowerShell see:  http://j.mp/psinstall" >PowerShellVersion>=v3.0</bal:Condition>
 
     <Chain>
       <MsiPackage SourceFile="OneGet.msi" />


### PR DESCRIPTION
OneGet currently requires PowerShell v3.0 or newer. Add a check to the
installation bundle to provide the user with a friendly message when
their PowerShell is too old. Also, fix link to OneGet license since
https: based URL wasn't launching for some reason.