### PR TITLE
added notes link to help install oneget package when missing.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,8 @@ You can follow [@PSOneGet on Twitter](http://twitter.com/PSOneGet) to be notifie
 * Learn how to [use the powershell cmdlets](https://github.com/OneGet/oneget/wiki/cmdlets) 
 * Read our [General Q and A](https://github.com/OneGet/oneget/wiki/Q-and-A)
 * Learn about the [8 Laws of Software Installation](https://github.com/OneGet/oneget/wiki/8-Laws-of-Software-Installation)
-* See the [documentation](https://github.com/OneGet/oneget/wiki) tab for more info.
-
+* See the [documentation](https://github.com/OneGet/oneget/wiki) tab for more info
+* Check out [install note](https://github.com/OneGet/oneget/issues/68).
 
 
 


### PR DESCRIPTION
It took me some time to figure out how to install oneget package cause it was missing from my windows 10 installation, so I think it was useful to report a note on the page documentation referring related issue.