### PR TITLE
NuGetProvider:Save-Package fails from local repo

### DIFF
--- a/Test/ModuleTests/tests/nuget.tests.ps1
+++ b/Test/ModuleTests/tests/nuget.tests.ps1
@@ -529,6 +529,16 @@ Describe "Save-Package" -Tags "Feature" {
        
         $package.Name | should be "TSDProvider"
         (test-path "$dest\TSDProvider*") | should be $true
+
+        # now let's run save-package from the local repository
+        $dest2 = "$destination\NeverEverExists2"
+        $package2 = save-package -name TSDProvider -path $dest2 -source $dest -provider $nuget -force
+        $package2.Name | should be "TSDProvider"
+        (test-path "$dest2\TSDProvider*") | should be $true
+
+        if (test-path "$dest2") {
+            Remove-Item $dest2 -force -Recurse
+        }
         if (test-path "$dest\TSDProvider*") {
             Remove-Item $dest\TSDProvider* -force
         }

--- a/src/Microsoft.PackageManagement/resources/Messages.Designer.cs
+++ b/src/Microsoft.PackageManagement/resources/Messages.Designer.cs
@@ -637,7 +637,7 @@ namespace Microsoft.PackageManagement.Internal.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User declined to install untrusted package &apos;{0}&apos;..
+        ///   Looks up a localized string similar to User declined to install package &apos;{0}&apos;..
         /// </summary>
         public static string UserDeclinedUntrustedPackageInstall {
             get {

--- a/src/Microsoft.PackageManagement/resources/Messages.resx
+++ b/src/Microsoft.PackageManagement/resources/Messages.resx
@@ -238,7 +238,7 @@
     <value>Uri Scheme '{0}' is not supported.</value>
   </data>
   <data name="UserDeclinedUntrustedPackageInstall" xml:space="preserve">
-    <value>User declined to install untrusted package '{0}'.</value>
+    <value>User declined to install package '{0}'.</value>
     <comment>0 -package name</comment>
   </data>
   <data name="FailedPowerShellMetaProvider" xml:space="preserve">

--- a/src/Microsoft.PowerShell.PackageManagement/resources/Messages.Designer.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/resources/Messages.Designer.cs
@@ -980,7 +980,7 @@ namespace Microsoft.PowerShell.PackageManagement.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User declined to install untrusted package ({0})..
+        ///   Looks up a localized string similar to User declined to install package ({0})..
         /// </summary>
         public static string UserDeclinedUntrustedPackageInstall {
             get {

--- a/src/Microsoft.PowerShell.PackageManagement/resources/Messages.resx
+++ b/src/Microsoft.PowerShell.PackageManagement/resources/Messages.resx
@@ -339,7 +339,7 @@
     <value>??? not used ???</value>
   </data>
   <data name="UserDeclinedUntrustedPackageInstall" xml:space="preserve">
-    <value>User declined to install untrusted package ({0}).</value>
+    <value>User declined to install package ({0}).</value>
     <comment>provider names</comment>
   </data>
   <data name="UnknownProviders" xml:space="preserve">


### PR DESCRIPTION
TFS# 8912792:OneGet:Error Message upon selecting "no" needs to be improved
TFS# 9099568: NuGetProvider:Save-Package fails from local repo. [See  Change](https://github.com/OneGet/NuGetProvider/commit/e4f12073864f0f1f6c6763c03b89f076437594ed)