### PR TITLE
Back compat with older builds of PowerShell Core

### DIFF
--- a/Test/ModuleTests/tests/legacy.tests.ps1
+++ b/Test/ModuleTests/tests/legacy.tests.ps1
@@ -1,8 +1,8 @@
 $IsLegacyTestRun = (Get-Variable -Name IsLegacyTestRun -ErrorAction Ignore) -and $global:IsLegacyTestRun
 
 Describe "Legacy tests" -Tags "Legacy" {
-    It "Blocks import on legacy PowerShell Core" -Skip:((-not $IsLegacyTestRun)) {
+    It "Can import on legacy PowerShell Core" -Skip:((-not $IsLegacyTestRun)) {
         try { Import-Module PackageManagement -RequiredVersion 1.1.6.0 } catch {}
-        Get-Module PackageManagement | should benullorempty
+        Get-Module PackageManagement | should not benullorempty
     }
 }

--- a/Test/run-tests.ps1
+++ b/Test/run-tests.ps1
@@ -148,7 +148,7 @@ if ($testframework -eq "fullclr")
 
     # Copying files to Packagemanagement and PowerShellGet folders
     Copy-Item "$PowerShellGetPath\*" $powershellGetfolder -force -verbose
-    Copy-Item "$TestBin\fullclr\*.dll" $packagemanagementfolder -force -Verbose
+    Copy-Item "$TestBin\fullclr\net451\*.dll" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psd1" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psm1" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.ps1" $packagemanagementfolder -force -Verbose
@@ -360,7 +360,7 @@ if ($testframework -eq "coreclr")
     Copy-Item "$CoreCLRTestHome\Examples\*.ps1" (Join-Path -Path $packagemanagementfolder -ChildPath "Examples")
 
      # copy the OneGet bits into powershell core
-    $OneGetBinaryPath ="$packagemanagementfolder\coreclr"
+    $OneGetBinaryPath ="$packagemanagementfolder\coreclr\netcoreapp2.0"
     if(-not (Test-Path -Path $OneGetBinaryPath))
     {
         New-Item -Path $OneGetBinaryPath -ItemType Directory -Force -Verbose
@@ -371,9 +371,10 @@ if ($testframework -eq "coreclr")
     }
 
 
-    Copy-Item "$TestBin\coreclr\*.dll" $OneGetBinaryPath -Force -Verbose
+    Copy-Item "$TestBin\coreclr\netcoreapp2.0\*.dll" $OneGetBinaryPath -Force -Verbose
 
     if ($powershellLegacyFolder) {
+        $OneGetBinaryPath ="$packagemanagementfolder\coreclr\netstandard1.6"
         $packagemanagementfolder = "$powershellLegacyFolder\Modules\PackageManagement\$PackageManagementVersion\"
         Write-Verbose ("OneGet Folder '{0}'" -f $packagemanagementfolder)
 
@@ -414,7 +415,7 @@ if ($testframework -eq "coreclr")
         }
 
 
-        Copy-Item "$TestBin\coreclr\*.dll" $OneGetBinaryPath -Force -Verbose
+        Copy-Item "$TestBin\coreclr\netstandard1.6\*.dll" $OneGetBinaryPath -Force -Verbose
     }
 
     $PSGetPath = "$powershellFolder\Modules\PowerShellGet\$PowerShellGetVersion\"

--- a/Test/run-tests.ps1
+++ b/Test/run-tests.ps1
@@ -435,7 +435,7 @@ if ($testframework -eq "coreclr")
     Copy-Item  "$($TestHome)\Unit\Providers\PSChained1Provider.psm1" "$($powershellFolder)\Modules" -force -verbose
     Copy-Item  "$($TestHome)\Unit\Providers\PSOneGetTestProvider" "$($powershellFolder)\Modules"  -Recurse -force -verbose
 
-    if ($powershellLegacyFolder) {
+    if ($powershellLegacyFolder -and $script:IsWindows) {
         $PSGetPath = "$powershellLegacyFolder\Modules\PowerShellGet\$PowerShellGetVersion\"
 
         Write-Verbose ("Legacy PowerShellGet Folder '{0}'" -f $PSGetPath)
@@ -556,7 +556,7 @@ if ($testframework -eq "coreclr")
             throw "$($x.'test-results'.failures) tests failed"
         }
     }
-    if ($powershellLegacyFolder) {
+    if ($powershellLegacyFolder -and $script:IsWindows) {
         # Tests on legacy version of PowerShell Core
         $command = ""
         $command += "Import-Module '$pesterFolder';`$global:IsLegacyTestRun=`$true;"
@@ -565,14 +565,7 @@ if ($testframework -eq "coreclr")
 
         Write-Host "(Legacy) CoreCLR: Calling $powershellLegacyFolder\powershell -command  $command"
 
-        if($script:IsWindows)
-        {
-            & "$powershellLegacyFolder\powershell" -command "& {$command}"
-        }
-        else
-        {
-            & powershell -command "& {$command}"
-        }
+        & "$powershellLegacyFolder\powershell" -command "& {$command}"
 
         $x = [xml](Get-Content -raw $testResultsFile)
         if ([int]$x.'test-results'.failures -gt 0)

--- a/Test/run-tests.ps1
+++ b/Test/run-tests.ps1
@@ -148,7 +148,7 @@ if ($testframework -eq "fullclr")
 
     # Copying files to Packagemanagement and PowerShellGet folders
     Copy-Item "$PowerShellGetPath\*" $powershellGetfolder -force -verbose
-    Copy-Item "$TestBin\fullclr\net451\*.dll" $packagemanagementfolder -force -Verbose
+    Copy-Item "$TestBin\fullclr\*.dll" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psd1" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psm1" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.ps1" $packagemanagementfolder -force -Verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
 - git submodule update --init
 - ps: nuget locals all -clear
 - ps: import-module c:\projects\oneget\test\TestUtility.psm1 -force
-- ps: cd .\src; .\bootstrap.ps1; .\build.ps1 -framework "net451" Release; .\build.ps1 -framework "netcoreapp2.0" Release
+- ps: cd .\src; .\bootstrap.ps1; .\build.ps1 -framework "net451" Release; .\build.ps1 -framework "netcoreapp2.0" Release; .\build.ps1 -framework "netstandard1.6" Release
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,11 @@
 PackageManagement is supported in Windows, Linux and MacOS now.
 We periodically make binary drop to [PowerShellCore][pscore],
 meaning PackageManagement is a part of PowerShell Core releases.
-Also PackageManagement and PowershellGet Modules are regularly getting updated in [PowerShellGallery.com.](https://www.PowerShellGallery.com)
-[pscore]: https://github.com/PowerShell/PowerShell.
+Also PackageManagement and PowershellGet Modules are regularly getting updated in [PowerShellGallery.com](https://www.PowerShellGallery.com).
+
 Thus checkout the latest version from PowerShellGallery.com.
+
+[pscore]: https://github.com/PowerShell/PowerShell
 
 ### Get Started!
 
@@ -47,7 +49,7 @@ You can follow [@PSOneGet on Twitter](http://twitter.com/PSOneGet) to be notifie
 [WMF5.0]: https://www.microsoft.com/en-us/download/details.aspx?id=50395
 [WMF5.1]: https://www.microsoft.com/en-us/download/details.aspx?id=53347
 
-#### What is PackageManagement (OneGet)?
+### What is PackageManagement (OneGet)?
 
 OneGet is a Windows package manager, renamed as PackageManagement. It is a unified interface to package management systems and aims to make Software Discovery, Installation and Inventory (SDII) work via a common set of cmdlets (and eventually a set of APIs). Regardless of the installation technology underneath, users can use these common cmdlets to install/uninstall packages, add/remove/query package repositories, and query a system for the software installed.
 
@@ -56,7 +58,7 @@ With OneGet, you can
 * Search and filter your repositories to find the packages you need
 * Seamlessly install and uninstall packages from one or more repositories with a single PowerShell command
 
-#####PackageManagement Architecture#####
+#### PackageManagement Architecture
 
 ![Image](./assets/OneGetArchitecture.PNG?raw=true)
 
@@ -107,7 +109,7 @@ You are installing the modules from an untrusted repository. If you trust this r
 you sure you want to install the modules from 'gallery'?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): y
 
-# 4. Find out if a module installed
+# 4. Find out if a module is installed
 
 PS E:\> Get-InstalledModule -name xjea
 
@@ -115,13 +117,13 @@ Version    Name        Repository      Description
 -------    ----        ----------       -----------
 0.3.0.0    xJea        gallery          Module with DSC Resources for Just Enough Admin (JEA)..
 
-# 5. Unisntall a module
+# 5. Uninstall a module
 
 PS E:\> Uninstall-Module -name xjea
 ```
-<br/>
+
 #### Working with http://www.NuGet.org repository
-<br/>
+
 ```powershell
 
 # find a package from the nuget repository
@@ -167,22 +169,18 @@ PS E:\> find-package -Source test -name jquery
 Name                Version          Source           Summary
 ----                -------          ------           -------
 jQuery              3.1.1            test             jQuery is a new kind of JavaScript Library....
-
 ```
-
-<br/>
 
 ### Try the latest PackageManagement (OneGet)
 
 You can run `install-module PowerShellGet` to install the latest PackageManagment and PowerShellGet from [PowerShellGallery](https://www.powershellgallery.com).
-[pscore]:https://github.com/PowerShell/PowerShell
 
 ### Downloading the Source Code
-OneGet repo has a number of other repositories embeded as submodules. To make things say, you can just clone recursively:
+OneGet repo has a number of other repositories embeded as submodules. To make things easy, you can just clone recursively:
 ```powershell
 git clone --recursive https://github.com/OneGet/oneget.git
 ```
-If you already cloned but forgot to use --recursive, you can update submodules manually:
+If you already cloned but forgot to use `--recursive`, you can update submodules manually:
 ```powershell
 git submodule update --init
 ```
@@ -190,9 +188,7 @@ git submodule update --init
 ### Building the code
 
 ``` powershell
-
-After clone this repository, go to the project folder
-
+# After cloning this repository, go to the project folder:
 > cd oneget
 > cd src
 
@@ -204,17 +200,17 @@ After clone this repository, go to the project folder
 
 #building OneGet for coreclr
 > .\build.ps1 netstandard1.6
+```
 
 If successfully built above, you should be able to see a folder:
-\oneget\src\out\PackageManagement gets created. The layout looks like below:
+`oneget\src\out\PackageManagement\` whose layout looks like below:
 
-      coreclr
-      fullclr
-      PackageManagement.format.ps1xml
-      PackageManagement.psd1
-      PackageManagement.psm1
-      PackageProviderFunctions.psm1
-```
+ * `coreclr`
+ * `fullclr`
+ * `PackageManagement.format.ps1xml`
+ * `PackageManagement.psd1`
+ * `PackageManagement.psm1`
+ * `PackageProviderFunctions.psm1`
 
 ### Deploying it
 
@@ -259,10 +255,7 @@ if you are running on Linux or Mac.
 > cd Test
 > & '.\run-tests.ps1' fullclr
 > & '.\run-tests.ps1' coreclr
-
-
 ```
-
 
 ### Understanding the OneGet code repository
 

--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,9 @@
 PackageManagement is supported in Windows, Linux and MacOS now.
 We periodically make binary drop to [PowerShellCore][pscore],
 meaning PackageManagement is a part of PowerShell Core releases.
-Also PackageManagement and PowershellGet Modules are regularly getting updated in [PowerShellGallery.com](https://www.PowerShellGallery.com).
-
+Also PackageManagement and PowershellGet Modules are regularly getting updated in [PowerShellGallery.com.](https://www.PowerShellGallery.com)
+[pscore]: https://github.com/PowerShell/PowerShell.
 Thus checkout the latest version from PowerShellGallery.com.
-
-[pscore]: https://github.com/PowerShell/PowerShell
 
 ### Get Started!
 
@@ -49,7 +47,7 @@ You can follow [@PSOneGet on Twitter](http://twitter.com/PSOneGet) to be notifie
 [WMF5.0]: https://www.microsoft.com/en-us/download/details.aspx?id=50395
 [WMF5.1]: https://www.microsoft.com/en-us/download/details.aspx?id=53347
 
-### What is PackageManagement (OneGet)?
+#### What is PackageManagement (OneGet)?
 
 OneGet is a Windows package manager, renamed as PackageManagement. It is a unified interface to package management systems and aims to make Software Discovery, Installation and Inventory (SDII) work via a common set of cmdlets (and eventually a set of APIs). Regardless of the installation technology underneath, users can use these common cmdlets to install/uninstall packages, add/remove/query package repositories, and query a system for the software installed.
 
@@ -58,7 +56,7 @@ With OneGet, you can
 * Search and filter your repositories to find the packages you need
 * Seamlessly install and uninstall packages from one or more repositories with a single PowerShell command
 
-#### PackageManagement Architecture
+#####PackageManagement Architecture#####
 
 ![Image](./assets/OneGetArchitecture.PNG?raw=true)
 
@@ -109,7 +107,7 @@ You are installing the modules from an untrusted repository. If you trust this r
 you sure you want to install the modules from 'gallery'?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): y
 
-# 4. Find out if a module is installed
+# 4. Find out if a module installed
 
 PS E:\> Get-InstalledModule -name xjea
 
@@ -117,13 +115,13 @@ Version    Name        Repository      Description
 -------    ----        ----------       -----------
 0.3.0.0    xJea        gallery          Module with DSC Resources for Just Enough Admin (JEA)..
 
-# 5. Uninstall a module
+# 5. Unisntall a module
 
 PS E:\> Uninstall-Module -name xjea
 ```
-
+<br/>
 #### Working with http://www.NuGet.org repository
-
+<br/>
 ```powershell
 
 # find a package from the nuget repository
@@ -169,18 +167,22 @@ PS E:\> find-package -Source test -name jquery
 Name                Version          Source           Summary
 ----                -------          ------           -------
 jQuery              3.1.1            test             jQuery is a new kind of JavaScript Library....
+
 ```
+
+<br/>
 
 ### Try the latest PackageManagement (OneGet)
 
 You can run `install-module PowerShellGet` to install the latest PackageManagment and PowerShellGet from [PowerShellGallery](https://www.powershellgallery.com).
+[pscore]:https://github.com/PowerShell/PowerShell
 
 ### Downloading the Source Code
-OneGet repo has a number of other repositories embeded as submodules. To make things easy, you can just clone recursively:
+OneGet repo has a number of other repositories embeded as submodules. To make things say, you can just clone recursively:
 ```powershell
 git clone --recursive https://github.com/OneGet/oneget.git
 ```
-If you already cloned but forgot to use `--recursive`, you can update submodules manually:
+If you already cloned but forgot to use --recursive, you can update submodules manually:
 ```powershell
 git submodule update --init
 ```
@@ -188,7 +190,9 @@ git submodule update --init
 ### Building the code
 
 ``` powershell
-# After cloning this repository, go to the project folder:
+
+After clone this repository, go to the project folder
+
 > cd oneget
 > cd src
 
@@ -200,17 +204,17 @@ git submodule update --init
 
 #building OneGet for coreclr
 > .\build.ps1 netstandard1.6
-```
 
 If successfully built above, you should be able to see a folder:
-`oneget\src\out\PackageManagement\` whose layout looks like below:
+\oneget\src\out\PackageManagement gets created. The layout looks like below:
 
- * `coreclr`
- * `fullclr`
- * `PackageManagement.format.ps1xml`
- * `PackageManagement.psd1`
- * `PackageManagement.psm1`
- * `PackageProviderFunctions.psm1`
+      coreclr
+      fullclr
+      PackageManagement.format.ps1xml
+      PackageManagement.psd1
+      PackageManagement.psm1
+      PackageProviderFunctions.psm1
+```
 
 ### Deploying it
 
@@ -255,7 +259,10 @@ if you are running on Linux or Mac.
 > cd Test
 > & '.\run-tests.ps1' fullclr
 > & '.\run-tests.ps1' coreclr
+
+
 ```
+
 
 ### Understanding the OneGet code repository
 

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Microsoft.PackageManagement.ArchiverProviders.csproj
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Microsoft.PackageManagement.ArchiverProviders.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.PackageManagement.ArchiverProviders</AssemblyName>
@@ -9,8 +9,9 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PackageManagement.ArchiverProviders</PackageId>
     <RuntimeIdentifiers>win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -56,7 +57,12 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR;COREv1</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <Compile Remove="Providers\Inbox\Common\*;Resources\*" />
   </ItemGroup>
   

--- a/src/Microsoft.PackageManagement.CoreProviders/Microsoft.PackageManagement.CoreProviders.csproj
+++ b/src/Microsoft.PackageManagement.CoreProviders/Microsoft.PackageManagement.CoreProviders.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.PackageManagement.CoreProviders</AssemblyName>
@@ -9,8 +9,9 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PackageManagement.CoreProviders</PackageId>
     <RuntimeIdentifiers>win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -28,7 +29,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Management.Automation" Version="6.0.0-beta.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <PackageReference Include="System.Management.Automation" Version="1.0.0-alpha9" />
   </ItemGroup>
 
@@ -63,7 +64,12 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR;COREv1</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <Compile Remove="Resources\Messages.Designer.cs;ProgramsProvider.cs" />
     <EmbeddedResource Remove="Resources\Messages.resx" />
   </ItemGroup>

--- a/src/Microsoft.PackageManagement.MetaProvider.PowerShell/Microsoft.PackageManagement.MetaProvider.PowerShell.csproj
+++ b/src/Microsoft.PackageManagement.MetaProvider.PowerShell/Microsoft.PackageManagement.MetaProvider.PowerShell.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.PackageManagement.MetaProvider.PowerShell</AssemblyName>
     <AssemblyOriginatorKeyFile>../signing/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PackageManagement.MetaProvider.PowerShell</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -26,7 +26,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Management.Automation" Version="6.0.0-beta.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <PackageReference Include="System.Management.Automation" Version="1.0.0-alpha9" />
   </ItemGroup>
 
@@ -61,7 +61,12 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR;COREv1</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <Compile Remove="Resources\Messages.Designer.cs" />
     <EmbeddedResource Remove="Resources\Messages.resx" />
   </ItemGroup>

--- a/src/Microsoft.PackageManagement.MsiProvider/Microsoft.PackageManagement.MsiProvider.csproj
+++ b/src/Microsoft.PackageManagement.MsiProvider/Microsoft.PackageManagement.MsiProvider.csproj
@@ -33,11 +33,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Compile Remove="Resources\Messages.Designer.cs" />
-    <EmbeddedResource Remove="Resources\Messages.resx" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
+++ b/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
@@ -1303,6 +1303,7 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
             try {
 
                 Assembly assembly = null;
+// This preprocessor directive is defined in build project (.NET Core csproj)
 #if COREv1
                 assembly = Microsoft.PowerShell.CoreCLR.AssemblyExtensions.LoadFrom(assemblyPath);
 #else

--- a/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
+++ b/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
@@ -1303,7 +1303,11 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
             try {
 
                 Assembly assembly = null;
+#if COREv1
+                assembly = Microsoft.PowerShell.CoreCLR.AssemblyExtensions.LoadFrom(assemblyPath);
+#else
                 assembly = Assembly.LoadFrom(assemblyPath);
+#endif
 
                 if (assembly == null) {
                     return false;

--- a/src/Microsoft.PackageManagement/Microsoft.PackageManagement.csproj
+++ b/src/Microsoft.PackageManagement/Microsoft.PackageManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.PackageManagement</AssemblyName>
@@ -9,8 +9,9 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PackageManagement</PackageId>
     <RuntimeIdentifiers>win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -24,10 +25,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Management.Automation" Version="6.0.0-beta.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <PackageReference Include="System.Management.Automation" Version="1.0.0-alpha9" />
   </ItemGroup>
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
@@ -59,7 +60,12 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR;COREv1</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <Compile Remove="Providers\Inbox\Common\*;Resources\Messages.Designer.cs" />
     <EmbeddedResource Remove="Resources\Messages.resx" />
   </ItemGroup>
@@ -69,12 +75,7 @@
     <EmbeddedResource Remove="Resources\Messages.resx" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.0.0-preview1-002111-00" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview1-25301-01" />
-    <PackageReference Include="NETStandard.Library.NETFramework" Version="2.0.0-preview1-25305-02" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25305-02" />
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
@@ -86,25 +87,38 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0-preview1-24530-04" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25305-02" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0-preview1-24530-04" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.0.0-preview1-002111-00" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview1-25301-01" />
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="2.0.0-preview1-25305-02" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25305-02" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0-preview1-24530-04" />
+    <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0-preview1-24530-04" />
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.3.0-preview1-24530-04" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.PackageManagement/Microsoft.PowerShell.PackageManagement.csproj
+++ b/src/Microsoft.PowerShell.PackageManagement/Microsoft.PowerShell.PackageManagement.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.PowerShell.PackageManagement</AssemblyName>
     <AssemblyOriginatorKeyFile>../signing/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PowerShell.PackageManagement</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -26,7 +26,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Management.Automation" Version="6.0.0-beta.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <PackageReference Include="System.Management.Automation" Version="1.0.0-alpha9" />
   </ItemGroup>
 
@@ -61,7 +61,12 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+ <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR;COREv1</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.0') Or ('$(TargetFramework)' == 'netstandard1.6') ">
     <Compile Remove="Resources\Messages.Designer.cs" />
     <EmbeddedResource Remove="Resources\Messages.resx" />
   </ItemGroup>

--- a/src/Microsoft.PowerShell.PackageManagement/PackageManagement.psm1
+++ b/src/Microsoft.PowerShell.PackageManagement/PackageManagement.psm1
@@ -6,20 +6,19 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename Packa
 
 # Summary: PackageManagement is supported on Windows PowerShell 3.0 or later, Nano Server and PowerShellCore
 $isCore = ($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')
+$binarySubPath = ''
 if ($isCore)
 {
-    # PackageManagement only works on versions of PowerShell Core built on .NETCoreApp 2.0 and above
-    # The following API was added in PackageManagement as a dependency
+    # Using the Assembly.LoadFrom API to determine if this is netcoreapp2.0 or if it's older
     $loadFromMethod = [System.Reflection.Assembly].GetMethods() | Where-Object { $_.Name -eq 'LoadFrom' }
-    if (-not $loadFromMethod)
+    if ($loadFromMethod)
     {
-        if ($PSVersionTable.ContainsKey('GitCommitId')) {
-            $psVersionString = $PSVersionTable.GitCommitId
-        } else {
-            $psVersionString = $PSVersionTable.PSVersion.ToString()
-        }
-        throw ($LocalizedData.OldPowerShellCoreVersion -f $psVersionString)
+        $binarySubPath = Join-Path -Path 'coreclr' -ChildPath 'netcoreapp2.0'
+    } else {
+        $binarySubPath = Join-Path -Path 'coreclr' -ChildPath 'netstandard1.6'
     }
+} else {
+    $binarySubPath = Join-Path -Path 'fullclr' -ChildPath 'net451'
 }
 
 # Set up some helper variables to make it easier to work with the module
@@ -38,12 +37,7 @@ $binaryModuleRoot = $script:PSModuleRoot
 if(-not (Test-Path -Path $OneGetModulePath))
 {
     # Import the appropriate nested binary module based on the current PowerShell version
-    $binaryModuleRoot = Join-Path -Path $script:PSModuleRoot -ChildPath 'fullclr'
-
-    if ($isCore) {
-        $binaryModuleRoot = Join-Path -Path $script:PSModuleRoot -ChildPath 'coreclr'
-    }
-    
+    $binaryModuleRoot = Join-Path -Path $script:PSModuleRoot -ChildPath $binarySubPath
     $OneGetModulePath = Join-Path -Path $binaryModuleRoot -ChildPath $script:PkgMgmt
 }
 

--- a/src/Microsoft.PowerShell.PackageManagement/PackageManagement.psm1
+++ b/src/Microsoft.PowerShell.PackageManagement/PackageManagement.psm1
@@ -18,7 +18,7 @@ if ($isCore)
         $binarySubPath = Join-Path -Path 'coreclr' -ChildPath 'netstandard1.6'
     }
 } else {
-    $binarySubPath = Join-Path -Path 'fullclr' -ChildPath 'net451'
+    $binarySubPath = 'fullclr'
 }
 
 # Set up some helper variables to make it easier to work with the module

--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -115,7 +115,7 @@ function Start-DotnetBootstrap {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
         $installScript = "dotnet-install.ps1"
         Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
-        & ./$installScript -c $Channel -Version $Version
+        & ./$installScript -c $Channel -v $Version
 
     } elseif ($IsWindows) {
         Write-Warning "Start-PSBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)"

--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -4,7 +4,7 @@ try {
     $Runtime = [System.Runtime.InteropServices.RuntimeInformation]
     $OSPlatform = [System.Runtime.InteropServices.OSPlatform]
 
-    $IsCoreCLR = $true
+    $IsCoreCLR = ($PSVersionTable.ContainsKey('PSEdition')) -and ($PSVersionTable.PSEdition -eq 'Core')
     $IsLinux = $Runtime::IsOSPlatform($OSPlatform::Linux)
     $IsOSX = $Runtime::IsOSPlatform($OSPlatform::OSX)
     $IsWindows = $Runtime::IsOSPlatform($OSPlatform::Windows)

--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -115,7 +115,7 @@ function Start-DotnetBootstrap {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
         $installScript = "dotnet-install.ps1"
         Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
-        & ./$installScript -c $Channel -v $Version
+        & ./$installScript -c $Channel -Version $Version
 
     } elseif ($IsWindows) {
         Write-Warning "Start-PSBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)"

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -111,7 +111,14 @@ $dscResourceItemsPackageSource = @("$solutionDir\Microsoft.PackageManagement.Dsc
 					  "$solutionDir\Microsoft.PackageManagement.DscResources\MSFT_PackageManagementSource\MSFT_PackageManagementSource.strings.psd1")
 
 $destinationDir = "$solutionDir/out/PackageManagement"
-$destinationDirBinaries = "$destinationDir/$packageFramework/$Framework"
+if (($Framework -eq "netcoreapp2.0") -or ($Framework -eq "netstandard1.6"))
+{
+    $destinationDirBinaries = "$destinationDir/$packageFramework/$Framework"
+} else 
+{
+    $destinationDirBinaries = "$destinationDir/$packageFramework"
+}
+
 $destinationDirDscResourcesBase = "$destinationDir/DSCResources"
 
 try

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,5 +1,5 @@
 ﻿param(
-    [ValidateSet("net451", "netcoreapp2.0")]
+    [ValidateSet("net451", "netcoreapp2.0", "netstandard1.6")]
     [string]$Framework = "netcoreapp2.0",
 
     [ValidateSet("Debug", "Release")]
@@ -61,7 +61,7 @@ Function CopyBinariesToDestinationDir($itemsToCopy, $destination, $framework, $c
 $solutionPath = Split-Path $MyInvocation.InvocationName
 $solutionDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($solutionPath)
 
-if ($Framework -eq "netcoreapp2.0")
+if (($Framework -eq "netcoreapp2.0") -or ($Framework -eq "netstandard1.6"))
 {
     $packageFramework ="coreclr"
     $assemblyNames = @(
@@ -111,7 +111,7 @@ $dscResourceItemsPackageSource = @("$solutionDir\Microsoft.PackageManagement.Dsc
 					  "$solutionDir\Microsoft.PackageManagement.DscResources\MSFT_PackageManagementSource\MSFT_PackageManagementSource.strings.psd1")
 
 $destinationDir = "$solutionDir/out/PackageManagement"
-$destinationDirBinaries = "$destinationDir/$packageFramework"
+$destinationDirBinaries = "$destinationDir/$packageFramework/$Framework"
 $destinationDirDscResourcesBase = "$destinationDir/DSCResources"
 
 try
@@ -153,9 +153,6 @@ if(test-path $packageFileName)
     Remove-Item $packageFileName -force
 }
 
-if ($packageFramework -eq "fullclr")
-{
-  Add-Type -assemblyname System.IO.Compression.FileSystem
-}
+Add-Type -assemblyname System.IO.Compression.FileSystem
 Write-Verbose "Zipping $sourcePath into $packageFileName" -verbose
 [System.IO.Compression.ZipFile]::CreateFromDirectory($sourcePath, $packageFileName) 

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -8,7 +8,7 @@ trap '
 ' INT
 
 get_url() {
-    release=v6.0.0-alpha.13
+    release=v6.0.0-beta.5
     echo "https://github.com/PowerShell/PowerShell/releases/download/$release/$1"
 }
 
@@ -24,7 +24,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_alpha.13-1.el7.centos.x86_64.rpm
+                package=powershell-6.0.0_beta.5-1.el7.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -34,10 +34,10 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-alpha.13-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.5-1ubuntu1.14.04.1_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-alpha.13-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.5-1ubuntu1.16.04.1_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
@@ -51,7 +51,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-alpha.13.pkg
+        package=powershell-6.0.0-beta.5-osx.10.12-x64.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -5,5 +5,5 @@ ulimit -n 4096
 git submodule update --init
 
 
-powershell -c "cd src; ./bootstrap.ps1; ./build.ps1 -framework "netstandard1.6" Release"
+powershell -c "cd src; ./bootstrap.ps1; ./build.ps1 -framework "netcoreapp2.0" Release"; ./build.ps1 -framework "netstandard1.6" Release"
 sudo powershell -c "cd Test;  ./run-tests.ps1 coreclr"

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -5,5 +5,5 @@ ulimit -n 4096
 git submodule update --init
 
 
-powershell -c "cd src; ./bootstrap.ps1; ./build.ps1 -framework "netcoreapp2.0" Release"; ./build.ps1 -framework "netstandard1.6" Release"
+powershell -c "cd src; ./bootstrap.ps1; ./build.ps1 -framework "netcoreapp2.0" Release; ./build.ps1 -framework "netstandard1.6" Release"
 sudo powershell -c "cd Test;  ./run-tests.ps1 coreclr"


### PR DESCRIPTION
This is mainly for the older Nano Server builds.

- Re-add netstandard1.6 build
- Package both netstandard1.6 and netcoreapp2.0 into module
- Use the older LoadFrom API when netstandard1.6
- Account for new folder structure in a couple of places
- Properly log errors as warnings when PackageProviderFunctions fails to load