### PR TITLE
Support prerelease values for *Version parameters of Get-Package and Uninstall-Package cmdlets

### DIFF
--- a/Test/ModuleTests/tests/nuget.tests.ps1
+++ b/Test/ModuleTests/tests/nuget.tests.ps1
@@ -1312,6 +1312,18 @@ Describe Get-Package -Tags "Feature" {
 			(Remove-Item -Recurse -Force -Path $destination\adept.nugetrunner*)
 		}
     }
+
+    It "Get-Package -RequiredVersion with prerelease version, Expect error" {
+        $package =  Get-Package -Name FooPackage -RequiredVersion '3.0.0-rc-3' -ErrorVariable ev -ErrorAction SilentlyContinue
+        $package | Should BeNullOrEmpty
+        $ev.FullyQualifiedErrorId | should be 'NoMatchFound,Microsoft.PowerShell.PackageManagement.Cmdlets.GetPackage'
+    }
+
+    It "Get-Package with prerelease version in -MinimumVersion and -MaximumVersion, Expect error" {
+        $package =  Get-Package -Name FooPackage -MinimumVersion '3.0.0-rc-3' -MaximumVersion '3.0.0-rc-3' -ErrorVariable ev -ErrorAction SilentlyContinue
+        $package | Should BeNullOrEmpty
+        $ev.FullyQualifiedErrorId | should be 'NoMatchFound,Microsoft.PowerShell.PackageManagement.Cmdlets.GetPackage'
+    }
 }
 
 Describe Uninstall-Package -Tags "Feature" {
@@ -1431,6 +1443,18 @@ Describe Uninstall-Package -Tags "Feature" {
         $Error.Clear()
         $package =  uninstall-package -name " " -warningaction:silentlycontinue -ErrorVariable wildcardError -ErrorAction SilentlyContinue        
         $wildcardError.FullyQualifiedErrorId | should be "WhitespacesAreNotSupported,Microsoft.PowerShell.PackageManagement.Cmdlets.UninstallPackage"
+    }
+
+    It "Uninstall-Package -RequiredVersion with prerelease version, Expect error" {
+        $package =  Uninstall-Package -Name FooPackage -RequiredVersion '3.0.0-rc-3' -ErrorVariable ev -ErrorAction SilentlyContinue
+        $package | Should BeNullOrEmpty
+        $ev.FullyQualifiedErrorId | should be 'NoMatchFound,Microsoft.PowerShell.PackageManagement.Cmdlets.UninstallPackage'
+    }
+
+    It "Uninstall-Package with prerelease version in -MinimumVersion and -MaximumVersion, Expect error" {
+        $package =  Uninstall-Package -Name FooPackage -MinimumVersion '3.0.0-rc-3' -MaximumVersion '3.0.0-rc-3' -ErrorVariable ev -ErrorAction SilentlyContinue
+        $package | Should BeNullOrEmpty
+        $ev.FullyQualifiedErrorId | should be 'NoMatchFound,Microsoft.PowerShell.PackageManagement.Cmdlets.UninstallPackage'
     }
 }
 

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackage.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackage.cs
@@ -71,10 +71,6 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 
         public override bool ProcessRecordAsync() {
             
-            ValidateVersion(RequiredVersion);
-            ValidateVersion(MinimumVersion);
-            ValidateVersion(MaximumVersion);
-
             // If AllVersions is specified, make sure other version parameters are not supplied
             if (AllVersions.IsPresent)
             {


### PR DESCRIPTION
Added support for prerelease version values for MinimumVersion, MaximumVersion and RequiredVersion parameters on Get-Package and Uninstall-Package cmdlets.

Resolves #306