### PR TITLE
Fix for credential forwarding

### DIFF
--- a/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
+++ b/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
@@ -344,6 +344,12 @@ function Set-TargetResource
     Write-Verbose -Message ($localizedData.StartSetPackage -f (GetMessageFromParameterDictionary $PSBoundParameters))
     
     $null = $PSBoundParameters.Remove("Ensure")
+
+    if ($PSBoundParameters.ContainsKey("SourceCredential"))
+    {
+        $PSBoundParameters.Add("Credential", $SourceCredential)
+        $null = $PSBoundParameters.Remove("SourceCredential")
+    }
     
     if ($AdditionalParameters)
     {


### PR DESCRIPTION
Currently this fails because the argument is `Credential` not `SourceCredential` for the `Install/Uninstall-Package` commands.

Resolves #345 