### PR TITLE
Fix to run on .NET Core 3.0 

### DIFF
--- a/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             il.LoadThis();
             il.LoadField(implementedMethodsField);
             il.LoadArgument(1);
-            il.CallVirutal(typeof(HashSet<string>).GetMethod("Contains"));
+            il.CallVirtual(typeof(HashSet<string>).GetMethod("Contains"));
             il.Return();
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             }
 
             // call the actual method implementation
-            il.CallVirutal(instanceMethod);
+            il.CallVirtual(instanceMethod);
 
             if (hasReturn)
             {
@@ -153,7 +153,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
                 il.LoadArgument(0);
                 il.Emit(OpCodes.Ldstr, instanceMethod.ToSignatureString());
                 il.LoadLocation(exc.LocalIndex);
-                il.Call(onUnhandledException);
+                il.CallVirtual(onUnhandledException);
                 il.Emit(OpCodes.Leave_S, setDefaultReturn);
             }
             else
@@ -206,7 +206,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             {
                 il.LoadArgument(i + 1);
             }
-            il.CallVirutal(delegateType.GetMethod("Invoke"));
+            il.CallVirtual(delegateType.GetMethod("Invoke"));
             il.Return();
         }
 

--- a/src/Microsoft.PackageManagement/Utility/Plugin/FluentIlExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Plugin/FluentIlExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin {
             il.Emit(OpCodes.Brfalse_S, label);
         }
 
-        public static void CallVirutal(this ILGenerator il, MethodInfo methodInfo) {
+        public static void CallVirtual(this ILGenerator il, MethodInfo methodInfo) {
             il.Emit(OpCodes.Callvirt, methodInfo);
         }
 


### PR DESCRIPTION
GenerateMethodForDirectCall creates an IL wrapper for a method in the provider. It allows a function OnUnhandledException to be defined in the interface and implemented in the provide. The generated code calls OnUnhandledException if there is an exception. However the methodInfo for the OUE method is from the interface so needs to be called as a virtual method. It looks like .NET Core 3.0 tightens up IL validation and now throws a "Bad IL Format" exception for this, where in .NET Core 2.0 it let it slide.

1-line fix is to CallVirtual instead of Call.

I believe this is a latent bug in our code. We could still raise it with the CoreFx team I guess since it is a change in behavior that could break others (and servicing packagemanagement with this issue could be interesting, since we can't download the new version with a broken version. But we should fix in any case.