### PR TITLE
StringComparison.CurrentCulture doesn't work as expected on linux with C locale

### DIFF
--- a/src/Microsoft.PackageManagement/Utility/Extensions/StringExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Extensions/StringExtensions.cs
@@ -342,14 +342,14 @@ namespace Microsoft.PackageManagement.Internal.Utility.Extensions {
         }
 
         public static bool IsTrue(this string text) {
-            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.CurrentCultureIgnoreCase);
+            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool? IsTruePreserveNull(this string text) {
             if (text == null) {
                 return null;
             }
-            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.CurrentCultureIgnoreCase);
+            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Microsoft.PackageManagement/providers/inbox/Common/Extensions/Extensions.cs
+++ b/src/Microsoft.PackageManagement/providers/inbox/Common/Extensions/Extensions.cs
@@ -192,7 +192,7 @@
 
         public static bool IsTrue(this string text)
         {
-            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.CurrentCultureIgnoreCase);
+            return !string.IsNullOrWhiteSpace(text) && text.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool CompareVersion(this string version1, string version2)


### PR DESCRIPTION
So .IsTrue() was always returning false

Resolves https://GitHub.com/powershell/PowerShellGet/issues/399 