### PR TITLE
Change -Force not to overwrite existing module

### DIFF
--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
@@ -617,7 +617,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             return packageSourceName;
         }
 
-        protected bool InstallPackages(params SoftwareIdentity[] packagesToInstall) {
+        protected bool InstallPackages(SoftwareIdentity[] packagesToInstall, bool forceReinstall) {
 
             if(packagesToInstall == null || packagesToInstall.Length == 0)
             {
@@ -666,7 +666,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                 }
 
                 // todo: this is a terribly simplistic way to do this, we'd better rethink this soon
-                if (!Force) {
+                if (!forceReinstall) {
                     if (installedPkgs.Any(each => each.Name.EqualsIgnoreCase(pkg.Name) && each.Version.EqualsIgnoreCase(pkg.Version))) {
                         // it looks like it's already installed.
                         // skip it.

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackage.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackage.cs
@@ -69,14 +69,16 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             }
         }
 
+        [Parameter]
+        public SwitchParameter ForceReinstall { get; set; }
 
         protected override void GenerateCmdletSpecificParameters(Dictionary<string, object> unboundArguments) {
 #if DEEP_DEBUG
-            Console.WriteLine("»» Entering GCSP ");
+            Console.WriteLine("Entering GCSP ");
 #endif
             if (!IsInvocation) {
 #if DEEP_DEBUG
-                Console.WriteLine("»»» Does not appear to be Invocation (locked:{0})", IsReentrantLocked);
+                Console.WriteLine("Does not appear to be Invocation (locked:{0})", IsReentrantLocked);
 #endif
                 var providerNames = PackageManagementService.AllProviderNames;
                 var whatsOnCmdline = GetDynamicParameterValue<string[]>("ProviderName");
@@ -95,7 +97,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             }
             else {
 #if DEEP_DEBUG
-                Console.WriteLine("»»» Does appear to be Invocation (locked:{0})", IsReentrantLocked);
+                Console.WriteLine("Does appear to be Invocation (locked:{0})", IsReentrantLocked);
 #endif
                 DynamicParameterDictionary.AddOrSet("ProviderName", new RuntimeDefinedParameter("ProviderName", typeof(string[]), new Collection<Attribute> {
                     new ParameterAttribute {
@@ -115,7 +117,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 
         public override bool ProcessRecordAsync() {
             if (IsPackageByObject) {
-                return InstallPackages(InputObject);
+                return InstallPackages(InputObject, this.ForceReinstall);
             }
             if (MyInvocation.BoundParameters.Count == 0 || (MyInvocation.BoundParameters.Count == 1 &&  MyInvocation.BoundParameters.ContainsKey("ProviderName")) ) {
                 // didn't pass in anything, (except maybe Providername)
@@ -154,7 +156,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             }
 
             // good list. Let's roll...
-            return base.InstallPackages(swids.ToArray());
+            return base.InstallPackages(swids.ToArray(), this.ForceReinstall);
         }
 
         protected override void ProcessPackage(PackageProvider provider, IEnumerable<string> searchKey, SoftwareIdentity package) {

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
             }
 
             if (IsPackageByObject) {
-                return InstallPackages(InputObject, (bool)this.Force);
+                return InstallPackages(InputObject, this.Force);
             }
 
             // otherwise, just do the search right now.

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
             }
 
             if (IsPackageByObject) {
-                return InstallPackages(InputObject);
+                return InstallPackages(InputObject, (bool)this.Force);
             }
 
             // otherwise, just do the search right now.
@@ -274,7 +274,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
             var list = ProcessMatchedDuplicates().ToArray();
 
             // Now install the provider
-            if(!base.InstallPackages(list)) {
+            if(!base.InstallPackages(list, this.Force)) {
                 return false;
             }
 


### PR DESCRIPTION
The -Force parameter in PowerShellGet and PackageManagement does too many different things:

- installs from untrusted repositories
- installs extra versions if the some earlier version is already installed
- reinstalls 1.0 over 1.0 (doing a needless download) if 1.0 is already present

This change removes the last case, because 99% of the time it is not what you want - I believe it's very unusual for the module to be corrupted on disk and really need to be redownloaded and reinstalled, but we end up doing it because the other uses of -Force are much more frequently required. Many scripts and install instructions specify -Force, which leads to slow re-downloads and re-installs.

Instead, this makes it so that if you already have exactly the correct version of a module installed and you want to refresh it, you have to use -ForceReinstall.

This change is only to Install-Package. If we're OK with this we can make the corresponding change to Install-Module.

This doesn't fully address the issues with the number of different flags to Install-Module (See https://github.com/PowerShell/PowerShellGet/issues/234) but I think it helps, despite adding yet another flag,, because -Force can be used without being a 'bad citizen'. -ForceReinstall is specific enough to the 'clean up this weird mess' scenario that it shouldn't need to be added to scripts. 

It could be argued this is a breaking change, but I think the cases where people are surprised and annoyed by having -Force reinstall everything outweigh the cases where people really need that to happen.