### PR TITLE
Fix deadlock when getting parameters in an event

### DIFF
--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
@@ -456,12 +456,12 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 #if DEEP_DEBUG
                         else {
                             if (MyInvocation == null) {
-                                Console.WriteLine("��� Attempt to get parameters MyInvocation == NULL");
+                                Console.WriteLine("»»» Attempt to get parameters MyInvocation == NULL");
                             } else {
                                 if (MyInvocation.MyCommand == null) {
-                                    Console.WriteLine("��� Attempt to get parameters MyCommand == NULL");
+                                    Console.WriteLine("»»» Attempt to get parameters MyCommand == NULL");
                                 } else {
-                                    Console.WriteLine("��� Attempt to get parameters Parameters == NULL");
+                                    Console.WriteLine("»»» Attempt to get parameters Parameters == NULL");
                                 }
                             }
                         }
@@ -501,7 +501,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 
                         if (null== CachedSelectedProviders || IsFailingEarly || IsCanceled ) {
 #if DEEP_DEBUG
-                            Console.WriteLine("��� Cancelled before we got finished doing dynamic parameters");
+                            Console.WriteLine("»»» Cancelled before we got finished doing dynamic parameters");
 #endif
                             // this happens if there is a serious failure early in the cmdlet
                             // i.e. - if the SelectedProviders comes back empty (due to aggressive filtering)

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
@@ -456,12 +456,12 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 #if DEEP_DEBUG
                         else {
                             if (MyInvocation == null) {
-                                Console.WriteLine("Â»Â»Â» Attempt to get parameters MyInvocation == NULL");
+                                Console.WriteLine("»»» Attempt to get parameters MyInvocation == NULL");
                             } else {
                                 if (MyInvocation.MyCommand == null) {
-                                    Console.WriteLine("Â»Â»Â» Attempt to get parameters MyCommand == NULL");
+                                    Console.WriteLine("»»» Attempt to get parameters MyCommand == NULL");
                                 } else {
-                                    Console.WriteLine("Â»Â»Â» Attempt to get parameters Parameters == NULL");
+                                    Console.WriteLine("»»» Attempt to get parameters Parameters == NULL");
                                 }
                             }
                         }
@@ -501,7 +501,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 
                         if (null== CachedSelectedProviders || IsFailingEarly || IsCanceled ) {
 #if DEEP_DEBUG
-                            Console.WriteLine("Â»Â»Â» Cancelled before we got finished doing dynamic parameters");
+                            Console.WriteLine("»»» Cancelled before we got finished doing dynamic parameters");
 #endif
                             // this happens if there is a serious failure early in the cmdlet
                             // i.e. - if the SelectedProviders comes back empty (due to aggressive filtering)


### PR DESCRIPTION
Fix from @SeeminglyScience:

>When getting dynamic parameters from a thread other than the pipeline
>thread, the call to CommandInfo.Parameters internally tries to get
>back to it using the PowerShell EventManager. If dynamic parameters
>are being obtained from an event that is being processed by the
>EventManager then a deadlock will occur.
>
>This change routes the call to CommandInfo.Parameters to the main
>thread using AsyncCmdlet.ExecuteOnMainThread, bypassing the
>EventManager.

I've taken a look at this, and it feels like it's the right fix and doesn't touch too much.

Happy to take responsibility for it.
