### PR TITLE
Fix/dsc additionalparameters switch

### DIFF
--- a/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
+++ b/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
@@ -392,12 +392,26 @@ function Add-AdditionalParameters
         $AdditionalParameters
     )
 
+    $rxTypePrefix = [regex]'^(?i)\[(?<type>[a-z]+)\]'
     if ($AdditionalParameters)
     {
         foreach($instance in $AdditionalParameters)
         {
             Write-Verbose ('AdditionalParameter: {0}, AdditionalParameterValue: {1}' -f $instance.Key, $instance.Value)
-            $null = $ParametersDictionary.Add($instance.Key, $instance.Value)
+            $key = $instance.Key
+            $value = $instance.Value
+            $match = $rxTypePrefix.Match($key)
+            if ($match.Success)
+            {
+                if (@('switch', 'bool') -icontains $match.Groups['type'].Value)
+                {
+                    Write-Verbose ('Parsing parameter ''{0}'' value ''{1}'' as bool and removing type prefix ''{2}''' -f $key, $value, $match.Value)
+                    $key = $key.Substring($match.Length)
+                    $value = [bool]::Parse($value)
+                }
+            }
+
+            $null = $ParametersDictionary.Add($key, $value)
         }
     }
 }

--- a/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
+++ b/src/Microsoft.PackageManagement.DscResources/MSFT_PackageManagement/MSFT_PackageManagement.psm1
@@ -98,15 +98,8 @@ function Get-TargetResource
     $null = $PSBoundParameters.Remove("Source")
     $null = $PSBoundParameters.Remove("SourceCredential")
 
-    if ($AdditionalParameters)
-    {
-         foreach($instance in $AdditionalParameters)
-         {
-             Write-Verbose ('AdditionalParameter: {0}, AdditionalParameterValue: {1}' -f $instance.Key, $instance.Value)
-             $null = $PSBoundParameters.Add($instance.Key, $instance.Value)
-         }
-    }
-    $null = $PSBoundParameters.Remove("AdditionalParameters")
+    Add-AdditionalParameters -ParametersDictionary $PSBoundParameters -AdditionalParameters $AdditionalParameters
+    $PSBoundParameters.Remove("AdditionalParameters")
     
     $verboseMessage =$localizedData.StartGetPackage -f (GetMessageFromParameterDictionary $PSBoundParameters),$env:PSModulePath
     Write-Verbose -Message $verboseMessage
@@ -351,15 +344,7 @@ function Set-TargetResource
         $null = $PSBoundParameters.Remove("SourceCredential")
     }
     
-    if ($AdditionalParameters)
-    {
-         foreach($instance in $AdditionalParameters)
-         {
-             Write-Verbose ('AdditionalParameter: {0}, AdditionalParameterValue: {1}' -f $instance.Key, $instance.Value)
-             $null = $PSBoundParameters.Add($instance.Key, $instance.Value)
-         }
-    }
-
+    Add-AdditionalParameters -ParametersDictionary $PSBoundParameters -AdditionalParameters $AdditionalParameters
     $PSBoundParameters.Remove("AdditionalParameters")
 
        
@@ -392,6 +377,30 @@ function Set-TargetResource
     $paramDictionary.Keys | ForEach-Object { $returnValue += "-{0} {1} " -f $_,$paramDictionary[$_] }
     return $returnValue
  }
+
+function Add-AdditionalParameters
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $ParametersDictionary,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AdditionalParameters
+    )
+
+    if ($AdditionalParameters)
+    {
+        foreach($instance in $AdditionalParameters)
+        {
+            Write-Verbose ('AdditionalParameter: {0}, AdditionalParameterValue: {1}' -f $instance.Key, $instance.Value)
+            $null = $ParametersDictionary.Add($instance.Key, $instance.Value)
+        }
+    }
+}
 
 Export-ModuleMember -function Get-TargetResource, Set-TargetResource, Test-TargetResource
 


### PR DESCRIPTION
When a DSC configuration, which uses the `PackageManagement` resource and attempts to pass provider-specific parameters via `AdditionalParameters`, is compiled, the parameters dictionary is serialized to `MSFT_KeyValuePair` objects, which hold a pair of strings. As a consequence, all type information about `AdditionalParameters` values is lost.

This poses a problem when a provider defines parameters whose types are not implictly convertible from string. Two such common types are `[switch]` and `[bool]`. For example, the `PowerShellGet` provider [defines several switch parameters](https://github.com/PowerShell/PowerShellGetv2/blob/b44dcfe8d064dcbd3fae1ebb21ea8160729ebfc2/src/PowerShellGet/public/providerfunctions/Get-DynamicOptions.ps1#L37), such as `InstallUpdate`, `AllowClobber` or `AllowPrereleaseVersions` - all of those are quite important. Unfortunately, attempting to pass values to those parameters in a DSC configuration [leads to failures](https://github.com/OneGet/oneget/issues/327), caused by attempts to directly assign a string value to a `SwitchParameter`.

This pull request solves this problem. Although the `PackageManagement` resource has no direct access to provider metadata, it can examine the parameters of the cmdlets it intends to call and determine their types. For `[switch]` and `[bool]` parameters, the resource parses the string value from `AdditionalParameters` to a `[bool]`, which is implicitly convertible to `[switch]`.

Example configuration, which fails on 1.4.7 and works after this PR:
```powershell
configuration TestSwitches
{
    Import-DscResource -Module @{ModuleName="PackageManagement"; ModuleVersion="1.4.8"} # assuming the changes are released in this version

    node localhost
    {
        PackageManagementSource PSGallery
        {
            Ensure = 'Present'
            Name = 'PSGallery'
            ProviderName = 'PowerShellGet'
            SourceLocation = 'https://www.powershellgallery.com/api/v2'
            InstallationPolicy = 'Trusted'
        }

        PackageManagement SF_PS_Http
        {
            Ensure = 'Present'
            Name = 'Microsoft.ServiceFabric.PowerShell.Http'
            MinimumVersion = '1.4.2-preview1'
            ProviderName = 'PowerShellGet'
            Source = 'PSGallery'
            AdditionalParameters = @{ AllowPrereleaseVersions = $true; InstallUpdate = $true; Scope = 'AllUsers'; AllowClobber = $true; SkipPublisherCheck = $true; Type = 'Module' }
            DependsOn = @('[PackageManagementSource]PSGallery')
        }
    }
}
```
